### PR TITLE
grpc PROTOCOL response content-type required. see: https://github.com…

### DIFF
--- a/src/grpc.erl
+++ b/src/grpc.erl
@@ -190,7 +190,7 @@ set_trailers(#{trailers := Metadata} = Stream, Trailers) ->
 send_headers(#{headers_sent := true} = Stream) ->
     Stream;
 send_headers(Stream) ->
-    send_headers(Stream, #{}).
+    send_headers(Stream, #{<<"content-type">>=><<"application/grpc+proto">>}).
 
 -spec send_headers(stream(), metadata()) -> stream().
 send_headers(#{cowboy_req := Req,


### PR DESCRIPTION
…/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md Response-Headers

support golang client

Signed-off-by: ericcao <caotao1570@qq.com>